### PR TITLE
Fix dependency problems and upgrade TimeEval version

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Those repositories also include their respective Python APIs:
 [![GutenTAG Badge](https://img.shields.io/badge/Repository-GutenTAG-blue?style=for-the-badge)](https://github.com/TimeEval/gutentag)
 [![Eval Badge](https://img.shields.io/badge/Repository-Eval-blue?style=for-the-badge)](https://github.com/TimeEval/timeeval)
 
-As initial resources for evaluations, we provide over 1,000 benchmark datasets and an increasing number of time series anomaly detection algorithms (over 70): 
+As initial resources for evaluations, we provide over 1,000 benchmark datasets and an increasing number of time series anomaly detection algorithms (over 70):
 
 [![Datasets Badge](https://img.shields.io/badge/Repository-Datasets-3a4750?style=for-the-badge)](https://timeeval.github.io/evaluation-paper/notebooks/Datasets.html)
 [![Algorithms Badge](https://img.shields.io/badge/Repository-Algorithms-3a4750?style=for-the-badge)](https://github.com/TimeEval/TimeEval-algorithms)
@@ -39,12 +39,21 @@ As initial resources for evaluations, we provide over 1,000 benchmark datasets a
 ## Installation and Usage (tl;dr)
 
 TimeEval is tested on Linux and Mac operating systems and supports Python 3.7 until 3.9.
-
 We don't support Python 3.10 or higher at the moment because downstream libraries are incompatible.
 
 > We haven't tested if TimeEval runs on Windows.
 > If you use Windows, please help us and test if TimeEval runs correctly.
 > If there are any issues, don't hesitate to contact us.
+
+By default, TimeEval does not automatically download all available algorithms (Docker images), because there are just too many.
+However, you can download them easily [from our registry](https://github.com/orgs/TimeEval/packages?repo_name=TimeEval-algorithms) using docker.
+Please download the correct tag for the algorithm, compatible with your version of TimeEval:
+
+```bash
+docker pull ghcr.io/timeeval/kmeans:0.3.0
+```
+
+After you have downloaded the algorithm images, you need to restart the GUI, so that it can find the new images.
 
 ### Web frontend
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ requests
 protobuf>=3.20,<4
 watchdog==2.1.9
 plotly==5.10.*
+altair==4.2.2  # newer versions of altair are not compatible with streamlit 1.11.1
+requests==2.31.0  # newer versions break the docker connection with "Error while fetching server API version: Not supported URL scheme http+docker"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.11.1
-timeeval==1.2.4
+timeeval>=1.4,<1.5
 timeeval-gutentag==0.2.0
 pyyaml
 numpy

--- a/timeeval_gui/🏠_Home.py
+++ b/timeeval_gui/🏠_Home.py
@@ -4,14 +4,14 @@ import streamlit as st
 def main():
     st.markdown("""
     # Welcome to the TimeEval GUI
-    
+
     TimeEval includes an extensive data generator and supports both interactive and batch evaluation scenarios.
     This novel toolkit, aims to ease the evaluation effort and help the community to provide more meaningful evaluations
     in the Time Series Anomaly Detection field.
-    
+
     This Tool has 3 main components:
-    
-    1. [GutenTAG](/GutenTAG) to generate time series 
+
+    1. [GutenTAG](/GutenTAG) to generate time series
     2. [Eval](/Eval) to run multiple anomaly detectors on multiple datasets
     3. [Results](/Results) to compare the quality of multiple anomaly detectors
     """)


### PR DESCRIPTION
- Fixes #2 by pinning the versions of `altair` and `requests`
- Additionally, upgrades to new TimeEval version to allow usage of the published algorithm images.